### PR TITLE
network fix

### DIFF
--- a/Tobi/network.tf
+++ b/Tobi/network.tf
@@ -2,16 +2,21 @@
 # Reusing Our Current VPC - Using secondary CIDR block for private subnets since public was already created #
 ##############################################################################################################
 
+locals {
+  prefix  = var.prefix
+  common_tags = {
+    Project = var.project
+  }
+}
+
+
 data "aws_vpc" "main" {
   id = var.vpc_id
 }
 
-
-
 data "aws_subnet" "private-1" {
   id = var.private1
 }
-
 
 data "aws_subnet" "private-2" {
   id = var.private2
@@ -25,22 +30,24 @@ data "aws_subnet" "public-1" {
   id = var.public1
 }
 
-data "aws_route_table" "public-1" {
-  subnet_id = data.aws_subnet.public-1.id
-}
+## route table and route not required for public subnets, theses are created automatically by AWS for default VPCs
 
-
-resource "aws_route_table_association" "public-1" {
-  subnet_id      = data.aws_subnet.public-1.id
-  route_table_id = data.aws_route_table.public-1.id
-}
-
-resource "aws_route" "public_internet_access_1" {
-  route_table_id         = data.aws_route_table.public-1.id
-  destination_cidr_block = "0.0.0.0/0"
-  vpc_id = data.aws_vpc.main.id
-}
-
+#resource "aws_route_table" "public-1" {
+#  subnet_id = data.aws_subnet.public-1.id
+#}
+#
+#
+#resource "aws_route_table_association" "public-1" {
+#  subnet_id      = data.aws_subnet.public-1.id
+#  route_table_id = data.aws_route_table.public-1.id
+#}
+#
+#resource "aws_route" "public_internet_access_1" {
+#  route_table_id         = data.aws_route_table.public-1.id
+#  destination_cidr_block = "0.0.0.0/0"
+#  vpc_id = data.aws_vpc.main.id
+#}
+#
 resource "aws_eip" "public-1" {
   vpc = true
 
@@ -50,7 +57,7 @@ resource "aws_eip" "public-1" {
   )
 }
 
-data "aws_nat_gateway" "public-1" {
+resource "aws_nat_gateway" "public-1" {
   allocation_id = aws_eip.public-1.id
   subnet_id     = data.aws_subnet.public-1.id
 
@@ -62,31 +69,32 @@ data "aws_nat_gateway" "public-1" {
 
 
 
-
 data "aws_subnet" "public-2" {
   id = var.public2
 }
 
-data "aws_route_table" "public-2" {
-  vpc_id = data.aws_vpc.main.id
+## route table and route not required for public subnets, theses are created automatically by AWS for default VPCs
 
-
-  tags = merge(
-    local.common_tags,
-    tomap({ "Name" = "${local.prefix}-public-2" })
-  )
-}
-
-resource "aws_route_table_association" "public-2" {
-  subnet_id      = data.aws_subnet.public-2.id
-  route_table_id = data.aws_route_table.public-2.id
-}
-
-resource "aws_route" "public_internet_access_2" {
-  route_table_id         = data.aws_route_table.public-2.id
-  destination_cidr_block = "0.0.0.0/0"
-  # gateway_id             = aws_internet_gateway.main.id
-}
+#resource "aws_route_table" "public-2" {
+#  vpc_id = data.aws_vpc.main.id
+#
+#
+#  tags = merge(
+#    local.common_tags,
+#    tomap({ "Name" = "${local.prefix}-public-2" })
+#  )
+#}
+#
+#resource "aws_route_table_association" "public-2" {
+#  subnet_id      = data.aws_subnet.public-2.id
+#  route_table_id = data.aws_route_table.public-2.id
+#}
+#
+#resource "aws_route" "public_internet_access_2" {
+#  route_table_id         = data.aws_route_table.public-2.id
+#  destination_cidr_block = "0.0.0.0/0"
+#  # gateway_id             = aws_internet_gateway.main.id
+#}
 
 resource "aws_eip" "public-2" {
   vpc = true
@@ -97,13 +105,13 @@ resource "aws_eip" "public-2" {
   )
 }
 
-data "aws_nat_gateway" "public-2" {
+resource "aws_nat_gateway" "public-2" {
   allocation_id = aws_eip.public-2.id
   subnet_id     = data.aws_subnet.public-2.id
 
   tags = merge(
     local.common_tags,
-    tomap({ "Name" = "${local.prefix}-public-2" })
+    tomap({ "Name" = "${local.prefix}-public-2"})
   )
 }
 
@@ -111,7 +119,7 @@ data "aws_nat_gateway" "public-2" {
 # Private Subnets - Outbound internt access only #
 ##################################################
 
-data "aws_route_table" "private-1" {
+resource "aws_route_table" "private-1" {
   vpc_id = data.aws_vpc.main.id
 
 
@@ -123,17 +131,17 @@ data "aws_route_table" "private-1" {
 
 resource "aws_route_table_association" "private-1" {
   subnet_id      = data.aws_subnet.private-1.id
-  route_table_id = data.aws_route_table.private-1.id
+  route_table_id = aws_route_table.private-1.id
 }
 
 resource "aws_route" "private_1_internet_out" {
-  route_table_id         = data.aws_route_table.private-1.id
-  nat_gateway_id         = data.aws_nat_gateway.public-1.id
+  route_table_id         = aws_route_table.private-1.id
+  nat_gateway_id         = aws_nat_gateway.public-1.id
   destination_cidr_block = "0.0.0.0/0"
 }
 
 
-data "aws_route_table" "private-2" {
+resource "aws_route_table" "private-2" {
   vpc_id = data.aws_vpc.main.id
 
   tags = merge(
@@ -144,11 +152,11 @@ data "aws_route_table" "private-2" {
 
 resource "aws_route_table_association" "private-2" {
   subnet_id      = data.aws_subnet.private-2.id
-  route_table_id = data.aws_route_table.private-2.id
+  route_table_id = aws_route_table.private-2.id
 }
 
 resource "aws_route" "private_2_internet_out" {
-  route_table_id         = data.aws_route_table.private-2.id
-  nat_gateway_id         = data.aws_nat_gateway.public-2.id
+  route_table_id         = aws_route_table.private-2.id
+  nat_gateway_id         = aws_nat_gateway.public-2.id
   destination_cidr_block = "0.0.0.0/0"
 }

--- a/Tobi/variables.tf
+++ b/Tobi/variables.tf
@@ -20,6 +20,7 @@ variable "db_password" {
   default     = "n<A8ynAtZWVAfZ8+MQ|uHMNbFG$*}"
 }
 
+## These resources already exist in AWS and we'd like to reuse them, hence we are pulling them to be used in this Terraform configuration
 variable "vpc_id" {
   default = "vpc-b09aa2c8"
 }


### PR DESCRIPTION
So I did the following:

- Added some comments to the code for future reference
- I set a `locals` for the `network.tf`, I couldn't find it elsewhere in the code and I needed this to be correctly set to be able to test my corrections. Depending on what you have, you might need to change this or not 
```
locals {
  prefix  = var.prefix
  common_tags = {
    Project = var.project
  }
}
```
- For the public subnets, since they are default subnets, they already have routes to the internet and don't need the routing config, so I commented those out. 

**Below is the output of my test using my personal AWS account, which shows a successful Terraform plan output for the config:**

```


Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_eip.public-1 will be created
  + resource "aws_eip" "public-1" {
      + allocation_id        = (known after apply)
      + association_id       = (known after apply)
      + carrier_ip           = (known after apply)
      + customer_owned_ip    = (known after apply)
      + domain               = (known after apply)
      + id                   = (known after apply)
      + instance             = (known after apply)
      + network_border_group = (known after apply)
      + network_interface    = (known after apply)
      + private_dns          = (known after apply)
      + private_ip           = (known after apply)
      + public_dns           = (known after apply)
      + public_ip            = (known after apply)
      + public_ipv4_pool     = (known after apply)
      + tags                 = {
          + "Name"    = "telpsyrx-be-public-1"
          + "Project" = "TelePsycRX_Backend"
        }
      + tags_all             = {
          + "Name"    = "telpsyrx-be-public-1"
          + "Project" = "TelePsycRX_Backend"
        }
      + vpc                  = true
    }

  # aws_eip.public-2 will be created
  + resource "aws_eip" "public-2" {
      + allocation_id        = (known after apply)
      + association_id       = (known after apply)
      + carrier_ip           = (known after apply)
      + customer_owned_ip    = (known after apply)
      + domain               = (known after apply)
      + id                   = (known after apply)
      + instance             = (known after apply)
      + network_border_group = (known after apply)
      + network_interface    = (known after apply)
      + private_dns          = (known after apply)
      + private_ip           = (known after apply)
      + public_dns           = (known after apply)
      + public_ip            = (known after apply)
      + public_ipv4_pool     = (known after apply)
      + tags                 = {
          + "Name"    = "telpsyrx-be-public-2"
          + "Project" = "TelePsycRX_Backend"
        }
      + tags_all             = {
          + "Name"    = "telpsyrx-be-public-2"
          + "Project" = "TelePsycRX_Backend"
        }
      + vpc                  = true
    }

  # aws_nat_gateway.public-1 will be created
  + resource "aws_nat_gateway" "public-1" {
      + allocation_id        = (known after apply)
      + connectivity_type    = "public"
      + id                   = (known after apply)
      + network_interface_id = (known after apply)
      + private_ip           = (known after apply)
      + public_ip            = (known after apply)
      + subnet_id            = "subnet-c84694a0"
      + tags                 = {
          + "Name"    = "telpsyrx-be-public-1"
          + "Project" = "TelePsycRX_Backend"
        }
      + tags_all             = {
          + "Name"    = "telpsyrx-be-public-1"
          + "Project" = "TelePsycRX_Backend"
        }
    }

  # aws_nat_gateway.public-2 will be created
  + resource "aws_nat_gateway" "public-2" {
      + allocation_id        = (known after apply)
      + connectivity_type    = "public"
      + id                   = (known after apply)
      + network_interface_id = (known after apply)
      + private_ip           = (known after apply)
      + public_ip            = (known after apply)
      + subnet_id            = "subnet-ab081fd0"
      + tags                 = {
          + "Name"    = "telpsyrx-be-public-2"
          + "Project" = "TelePsycRX_Backend"
        }
      + tags_all             = {
          + "Name"    = "telpsyrx-be-public-2"
          + "Project" = "TelePsycRX_Backend"
        }
    }

  # aws_route.private_1_internet_out will be created
  + resource "aws_route" "private_1_internet_out" {
      + destination_cidr_block = "0.0.0.0/0"
      + id                     = (known after apply)
      + instance_id            = (known after apply)
      + instance_owner_id      = (known after apply)
      + nat_gateway_id         = (known after apply)
      + network_interface_id   = (known after apply)
      + origin                 = (known after apply)
      + route_table_id         = (known after apply)
      + state                  = (known after apply)
    }

  # aws_route.private_2_internet_out will be created
  + resource "aws_route" "private_2_internet_out" {
      + destination_cidr_block = "0.0.0.0/0"
      + id                     = (known after apply)
      + instance_id            = (known after apply)
      + instance_owner_id      = (known after apply)
      + nat_gateway_id         = (known after apply)
      + network_interface_id   = (known after apply)
      + origin                 = (known after apply)
      + route_table_id         = (known after apply)
      + state                  = (known after apply)
    }

  # aws_route_table.private-1 will be created
  + resource "aws_route_table" "private-1" {
      + arn              = (known after apply)
      + id               = (known after apply)
      + owner_id         = (known after apply)
      + propagating_vgws = (known after apply)
      + route            = (known after apply)
      + tags             = {
          + "Name"    = "telpsyrx-be-private-1"
          + "Project" = "TelePsycRX_Backend"
        }
      + tags_all         = {
          + "Name"    = "telpsyrx-be-private-1"
          + "Project" = "TelePsycRX_Backend"
        }
      + vpc_id           = "vpc-b774bedf"
    }

  # aws_route_table.private-2 will be created
  + resource "aws_route_table" "private-2" {
      + arn              = (known after apply)
      + id               = (known after apply)
      + owner_id         = (known after apply)
      + propagating_vgws = (known after apply)
      + route            = (known after apply)
      + tags             = {
          + "Name"    = "telpsyrx-be-private-2"
          + "Project" = "TelePsycRX_Backend"
        }
      + tags_all         = {
          + "Name"    = "telpsyrx-be-private-2"
          + "Project" = "TelePsycRX_Backend"
        }
      + vpc_id           = "vpc-b774bedf"
    }

  # aws_route_table_association.private-1 will be created
  + resource "aws_route_table_association" "private-1" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = "subnet-0b921310962561947"
    }

  # aws_route_table_association.private-2 will be created
  + resource "aws_route_table_association" "private-2" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = "subnet-0b1db1030a8193209"
    }

Plan: 10 to add, 0 to change, 0 to destroy.

```